### PR TITLE
Initialize client-only stock tracker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+.env

--- a/README.md
+++ b/README.md
@@ -1,1 +1,33 @@
-# Codex-Stk
+# Codex Stk
+
+Client-only React app for tracking Canadian & U.S. stocks with CAD-only calculations. No persistence or analytics.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Create a `.env` with your Alpha Vantage key:
+   ```
+   VITE_ALPHA_VANTAGE_KEY=YOUR_KEY
+   ```
+3. Run dev server:
+   ```bash
+   npm run dev
+   ```
+4. Run tests:
+   ```bash
+   npm test
+   ```
+
+## Features
+- Add/edit/delete positions
+- Fetch latest prices & dividends on demand
+- CAD calculations only
+- Export/Import portfolio to/from JSON files
+- No storage; data lives only in memory
+
+## Notes
+- API calls use Alpha Vantage and are subject to rate limits.
+- The app sends no portfolio data to any server except when fetching public market data.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Codex Stk</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "codex-stk",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.14",
+    "@types/react-dom": "^18.2.6",
+    "@vitejs/plugin-react": "^4.0.3",
+    "typescript": "^5.2.0",
+    "vite": "^5.0.0",
+    "vitest": "^1.0.0",
+    "tailwindcss": "^3.3.0",
+    "postcss": "^8.4.27",
+    "autoprefixer": "^10.4.14",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/jest-dom": "^6.2.0"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,83 @@
+import { useState } from 'react';
+import PositionForm from './PositionForm';
+import PositionsTable from './PositionsTable';
+import PortfolioSummary from './PortfolioSummary';
+import { Position, PortfolioFile } from './types';
+import { fetchLatestPrice } from './api/prices';
+import { fetchDividendsSince } from './api/dividends';
+import { totalDividends } from './utils/calc';
+import { exportPortfolio, importPortfolio } from './utils/jsonIO';
+
+export default function App() {
+  const [positions, setPositions] = useState<Position[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const add = (p: Position) => setPositions([...positions, p]);
+
+  const del = (idx: number) => {
+    setPositions(positions.filter((_, i) => i !== idx));
+  };
+
+  const refreshAll = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const updated = await Promise.all(
+        positions.map(async (p) => {
+          try {
+            const price = await fetchLatestPrice(p.ticker);
+            const divs = await fetchDividendsSince(p.ticker, p.purchaseDate);
+            return {
+              ...p,
+              latestPriceCad: price,
+              dividendsCad: totalDividends(divs, p.shares),
+            };
+          } catch (e) {
+            setError('API error or rate limit');
+            return p;
+          }
+        })
+      );
+      setPositions(updated);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const exportJson = () => {
+    const file: PortfolioFile = { version: '1.0', currency: 'CAD', positions };
+    exportPortfolio(file);
+  };
+
+  const importJson = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (!e.target.files?.length) return;
+    try {
+      const data = await importPortfolio(e.target.files[0]);
+      setPositions(data.positions);
+    } catch (err) {
+      setError('Invalid JSON file');
+    }
+    e.target.value = '';
+  };
+
+  return (
+    <div className="max-w-3xl mx-auto p-4">
+      <h1 className="text-2xl mb-4">Codex Stock Tracker</h1>
+      <PositionForm onAdd={add} />
+      <div className="flex gap-2 mt-4">
+        <button onClick={refreshAll} className="bg-green-500 text-white px-2 py-1 rounded" disabled={loading}>
+          {loading ? 'Loading...' : 'Refresh All'}
+        </button>
+        <button onClick={exportJson} className="bg-blue-500 text-white px-2 py-1 rounded">Export JSON</button>
+        <label className="bg-gray-500 text-white px-2 py-1 rounded cursor-pointer">
+          Import JSON
+          <input type="file" accept="application/json" className="hidden" onChange={importJson} />
+        </label>
+      </div>
+      {error && <div className="text-red-500 mt-2">{error}</div>}
+      <PortfolioSummary positions={positions} />
+      <PositionsTable positions={positions} onDelete={del} />
+    </div>
+  );
+}

--- a/src/PortfolioSummary.tsx
+++ b/src/PortfolioSummary.tsx
@@ -1,0 +1,23 @@
+import { Position } from './types';
+import { investedAmount, currentValue } from './utils/calc';
+
+interface Props {
+  positions: Position[];
+}
+
+export default function PortfolioSummary({ positions }: Props) {
+  const totalInvested = positions.reduce((s, p) => s + investedAmount(p), 0);
+  const totalCurrent = positions.reduce((s, p) => s + currentValue(p), 0);
+  const gain = totalCurrent - totalInvested;
+  const gainPct = totalInvested ? (gain / totalInvested) * 100 : 0;
+  const totalDivs = positions.reduce((s, p) => s + (p.dividendsCad || 0), 0);
+
+  return (
+    <div className="p-4 border rounded mt-4">
+      <div>Total Invested: {totalInvested.toFixed(2)} CAD</div>
+      <div>Current Value: {totalCurrent.toFixed(2)} CAD</div>
+      <div>Gain/Loss: {gain.toFixed(2)} CAD ({gainPct.toFixed(2)}%)</div>
+      <div>Total Dividends: {totalDivs.toFixed(2)} CAD</div>
+    </div>
+  );
+}

--- a/src/PositionForm.tsx
+++ b/src/PositionForm.tsx
@@ -1,0 +1,50 @@
+import { useState } from 'react';
+import { Position } from './types';
+
+interface Props {
+  onAdd: (p: Position) => void;
+}
+
+export default function PositionForm({ onAdd }: Props) {
+  const [ticker, setTicker] = useState('');
+  const [purchaseDate, setPurchaseDate] = useState('');
+  const [shares, setShares] = useState('');
+  const [price, setPrice] = useState('');
+
+  const submit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const p: Position = {
+      ticker,
+      purchaseDate,
+      shares: Number(shares),
+      purchasePriceCad: Number(price),
+    };
+    onAdd(p);
+    setTicker('');
+    setPurchaseDate('');
+    setShares('');
+    setPrice('');
+  };
+
+  return (
+    <form onSubmit={submit} className="flex flex-col gap-2 p-4 border rounded">
+      <label className="flex flex-col">
+        Ticker
+        <input value={ticker} onChange={e => setTicker(e.target.value)} required className="border p-1" />
+      </label>
+      <label className="flex flex-col">
+        Purchase Date
+        <input type="date" value={purchaseDate} onChange={e => setPurchaseDate(e.target.value)} required className="border p-1" />
+      </label>
+      <label className="flex flex-col">
+        Shares
+        <input type="number" value={shares} onChange={e => setShares(e.target.value)} required className="border p-1" />
+      </label>
+      <label className="flex flex-col">
+        Purchase Price (CAD)
+        <input type="number" step="0.01" value={price} onChange={e => setPrice(e.target.value)} required className="border p-1" />
+      </label>
+      <button type="submit" className="bg-blue-500 text-white px-2 py-1 rounded">Add Position</button>
+    </form>
+  );
+}

--- a/src/PositionsTable.tsx
+++ b/src/PositionsTable.tsx
@@ -1,0 +1,44 @@
+import { Position } from './types';
+import { investedAmount, currentValue, gainLossValue, gainLossPercent } from './utils/calc';
+
+interface Props {
+  positions: Position[];
+  onDelete: (index: number) => void;
+}
+
+export default function PositionsTable({ positions, onDelete }: Props) {
+  return (
+    <table className="min-w-full border mt-4">
+      <thead>
+        <tr className="bg-gray-100">
+          <th className="p-2 border">Ticker</th>
+          <th className="p-2 border">Shares</th>
+          <th className="p-2 border">Invested</th>
+          <th className="p-2 border">Current Price</th>
+          <th className="p-2 border">Current Value</th>
+          <th className="p-2 border">Gain/Loss $</th>
+          <th className="p-2 border">Gain/Loss %</th>
+          <th className="p-2 border">Dividends</th>
+          <th className="p-2 border">Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        {positions.map((p, idx) => (
+          <tr key={idx} className="text-center">
+            <td className="border p-1">{p.ticker}</td>
+            <td className="border p-1">{p.shares}</td>
+            <td className="border p-1">{investedAmount(p).toFixed(2)}</td>
+            <td className="border p-1">{p.latestPriceCad?.toFixed(2) ?? '-'}</td>
+            <td className="border p-1">{currentValue(p).toFixed(2)}</td>
+            <td className="border p-1">{gainLossValue(p).toFixed(2)}</td>
+            <td className="border p-1">{gainLossPercent(p).toFixed(2)}</td>
+            <td className="border p-1">{p.dividendsCad?.toFixed(2) ?? '-'}</td>
+            <td className="border p-1">
+              <button onClick={() => onDelete(idx)} className="text-red-500">Delete</button>
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/src/api/dividends.ts
+++ b/src/api/dividends.ts
@@ -1,0 +1,19 @@
+export async function fetchDividendsSince(ticker: string, purchaseDate: string): Promise<number[]> {
+  const key = import.meta.env.VITE_ALPHA_VANTAGE_KEY;
+  const url = `https://www.alphavantage.co/query?function=TIME_SERIES_MONTHLY_ADJUSTED&symbol=${encodeURIComponent(ticker)}&apikey=${key}`;
+  const res = await fetch(url);
+  if (!res.ok) throw new Error('Dividend fetch failed');
+  const json = await res.json();
+  const series = json['Monthly Adjusted Time Series'];
+  if (!series) throw new Error('Dividend data not available');
+  const start = new Date(purchaseDate);
+  const dividends: number[] = [];
+  for (const [dateStr, data] of Object.entries<any>(series)) {
+    const date = new Date(dateStr);
+    if (date >= start) {
+      const amt = parseFloat((data as any)['7. dividend amount']);
+      if (amt > 0) dividends.push(amt);
+    }
+  }
+  return dividends;
+}

--- a/src/api/prices.ts
+++ b/src/api/prices.ts
@@ -1,0 +1,10 @@
+export async function fetchLatestPrice(ticker: string): Promise<number> {
+  const key = import.meta.env.VITE_ALPHA_VANTAGE_KEY;
+  const url = `https://www.alphavantage.co/query?function=GLOBAL_QUOTE&symbol=${encodeURIComponent(ticker)}&apikey=${key}`;
+  const res = await fetch(url);
+  if (!res.ok) throw new Error('Price fetch failed');
+  const json = await res.json();
+  const price = json['Global Quote']?.['05. price'];
+  if (!price) throw new Error('Price not available');
+  return parseFloat(price);
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,14 @@
+export interface Position {
+  ticker: string;
+  purchaseDate: string; // YYYY-MM-DD
+  shares: number;
+  purchasePriceCad: number;
+  latestPriceCad?: number;
+  dividendsCad?: number;
+}
+
+export interface PortfolioFile {
+  version: '1.0';
+  currency: 'CAD';
+  positions: Position[];
+}

--- a/src/utils/calc.test.ts
+++ b/src/utils/calc.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { investedAmount, currentValue, gainLossValue, gainLossPercent, totalDividends } from './calc';
+import { Position } from '../types';
+
+describe('calc utils', () => {
+  const position: Position = {
+    ticker: 'TEST',
+    purchaseDate: '2024-01-01',
+    shares: 100,
+    purchasePriceCad: 10,
+    latestPriceCad: 12.5,
+  };
+
+  it('calculates current value and gain', () => {
+    expect(investedAmount(position)).toBe(1000);
+    expect(currentValue(position)).toBe(1250);
+    expect(gainLossValue(position)).toBe(250);
+    expect(gainLossPercent(position)).toBe(25);
+  });
+
+  it('calculates total dividends', () => {
+    const divs = [0.30, 0.32, 0.32];
+    expect(totalDividends(divs, position.shares)).toBeCloseTo(94, 5);
+  });
+});

--- a/src/utils/calc.ts
+++ b/src/utils/calc.ts
@@ -1,0 +1,14 @@
+import { Position } from '../types';
+
+export const investedAmount = (p: Position) => p.shares * p.purchasePriceCad;
+
+export const currentValue = (p: Position) =>
+  p.latestPriceCad ? p.latestPriceCad * p.shares : 0;
+
+export const gainLossValue = (p: Position) => currentValue(p) - investedAmount(p);
+
+export const gainLossPercent = (p: Position) =>
+  investedAmount(p) ? (gainLossValue(p) / investedAmount(p)) * 100 : 0;
+
+export const totalDividends = (dividends: number[], shares: number) =>
+  dividends.reduce((s, d) => s + d, 0) * shares;

--- a/src/utils/jsonIO.test.ts
+++ b/src/utils/jsonIO.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { importPortfolio } from './jsonIO';
+
+const valid = {
+  version: '1.0',
+  currency: 'CAD',
+  positions: [],
+};
+
+describe('jsonIO', () => {
+  it('imports valid portfolio', async () => {
+    const file = new File([JSON.stringify(valid)], 'p.json', { type: 'application/json' });
+    const data = await importPortfolio(file);
+    expect(data.version).toBe('1.0');
+  });
+
+  it('rejects invalid portfolio', async () => {
+    const file = new File([JSON.stringify({})], 'bad.json', { type: 'application/json' });
+    await expect(importPortfolio(file)).rejects.toThrow();
+  });
+});

--- a/src/utils/jsonIO.ts
+++ b/src/utils/jsonIO.ts
@@ -1,0 +1,20 @@
+import { PortfolioFile } from '../types';
+
+export function exportPortfolio(data: PortfolioFile) {
+  const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = 'portfolio_cad.json';
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+export async function importPortfolio(file: File): Promise<PortfolioFile> {
+  const text = await file.text();
+  const json = JSON.parse(text);
+  if (json.version !== '1.0' || json.currency !== 'CAD' || !Array.isArray(json.positions)) {
+    throw new Error('Invalid portfolio file');
+  }
+  return json as PortfolioFile;
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,8 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- scaffold Vite + TypeScript React app with Tailwind styling
- add portfolio management components and CAD-only calculations
- implement JSON export/import utilities and example tests

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_b_6898fd292d88832392bfef2740cc5f08